### PR TITLE
counsel-gtags--read-tag: Ignore case of input

### DIFF
--- a/counsel-gtags.el
+++ b/counsel-gtags.el
@@ -175,7 +175,9 @@ This variable does not have any effect unless
 
 (defun counsel-gtags--read-tag (type)
   (let ((default-val (and counsel-gtags-use-input-at-point (thing-at-point 'symbol)))
-        (prompt (assoc-default type counsel-gtags--prompts)))
+        (prompt (assoc-default type counsel-gtags--prompts))
+        (ivy-case-fold-search-default (or (and counsel-gtags-ignore-case 'always)
+                                          ivy-case-fold-search-default)))
     (ivy-read prompt (counsel-gtags--complete-candidates type)
               :initial-input default-val
               :unwind (lambda ()


### PR DESCRIPTION
If the option `counsel-gtags-ignore-case` is `t`, the search for a matching tag should always be case-insensitive, regardless of the input. 

By default, a case-sensitive search is performed if the input is not all lowercase.