### PR TITLE
Remove carriage return from candidates.

### DIFF
--- a/counsel-gtags.el
+++ b/counsel-gtags.el
@@ -147,7 +147,12 @@ This variable does not have any effect unless
   (let ((cmd-options (counsel-gtags--command-options type)))
     (push "-c" cmd-options)
     (counsel--async-command
-     (mapconcat #'identity (cons "global" (reverse cmd-options)) " "))
+     (mapconcat #'identity (cons "global" (reverse cmd-options)) " ")
+     nil
+     (lambda (process str)
+       (counsel--async-filter
+        process
+        (replace-regexp-in-string "\r\n" "\n" str))))
     nil))
 
 (defun counsel-gtags--file-and-line (candidate)


### PR DESCRIPTION
Hi,

  In Cygwin, every candidate contains a carriage return, shown as `^M`, at the end when doing `counsel-gtags-dwim`, so that no result will be matched by selecting any candidate. The minibuffer looks like below:

    2 Find Definition:
    Foo^M
    Bar^M

  Using `global` in both shells of Cygwin and Linux with the exactly same tag files indicates that
the output in Cygwin contains an additional CR.
  Cygwin:

    $ global --result=grep -c | head | hexdump -C | head -n 2
    00000000  41 42 53 54 52 41 43 54  0d 0a 41 43 43 4f 55 4e  |ABSTRACT..ACCOUN|
    00000010  54 5f 41 55 54 48 5f 54  59 50 45 0d 0a 41 44 55  |T_AUTH_TYPE..ADU|

  Linux:

    $ global --result=grep -c | head | hexdump -C | head -n 2
    00000000  41 42 53 54 52 41 43 54  0a 41 43 43 4f 55 4e 54  |ABSTRACT.ACCOUNT|
    00000010  5f 41 55 54 48 5f 54 59  50 45 0a 41 44 55 4c 54  |_AUTH_TYPE.ADULT|

  This PR fixes it by simply replacing every `\r\n` with `\n`.