### PR TITLE
Don't resolve symbolic links.

### DIFF
--- a/counsel-gtags.el
+++ b/counsel-gtags.el
@@ -374,7 +374,7 @@ Prompt for ROOTDIR and LABEL if not given.  This command is asynchronous."
       (error "This buffer is not related to file."))
     (if (file-remote-p buffile)
         (tramp-file-name-localname (tramp-dissect-file-name buffile))
-      (file-truename buffile))))
+      buffile)))
 
 (defun counsel-gtags--read-tag-directory ()
   (let ((dir (read-directory-name "Directory tag generated: " nil nil t)))


### PR DESCRIPTION
Hi,

It failed to work when there is symbolic links inside the project root,
let's take this test directory tree for example,

    /home/whatacold/tmp/test-gtags-symlink $ tree
    .
    ├── proj
    │   ├── external -> ../proj-external
    │   ├── foo.cpp
    │   ├── GPATH
    │   ├── GRTAGS
    │   └── GTAGS
    └── proj-external
        └── bar.cpp
    
    3 directories, 5 files

Within bar.cpp(`buffer-file-name` is `/home/whatacold/tmp/test-gtags-symlink/proj/external/bar.cpp`),
when I try to jump to a definition in foo.cpp, it will fail.

I added some code to print the command,
which is `global "--result=grep" "--from-here=4:/home/whatacold/tmp/test-gtags-symlink/proj-external/bar.cpp" "foo"`,
it's obvious that the argument of `--from-here` is out of the project tree.

P.S. I have tested that this doesn't solve https://github.com/syohex/emacs-counsel-gtags/issues/23
